### PR TITLE
✨ feat: Add abstract provider class for registering FastAPI app components

### DIFF
--- a/src/chaserland_api_gateway/core/provider.py
+++ b/src/chaserland_api_gateway/core/provider.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+
+class AbstractFastAPIComponentProvider(ABC):
+    """Provider interface for registering FastAPI app components."""
+
+    @staticmethod
+    @abstractmethod
+    def register(app):
+        """Register FastAPI app components.
+
+        Args:
+            app (FastAPI): FastAPI app instance.
+
+        Raises:
+            NotImplementedError: Method not implemented.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This pull request adds an abstract provider class for registering FastAPI app components. The `AbstractFastAPIComponentProvider` class provides a provider interface for registering FastAPI app components. It includes a `register` method that takes a FastAPI app instance as an argument and raises a `NotImplementedError` if not implemented. This class can be used as a base class for implementing specific component providers.