### PR TITLE
🎈 perf: Close redis connection pool on shutdown

### DIFF
--- a/src/chaserland_api_gateway/providers/lifespan.py
+++ b/src/chaserland_api_gateway/providers/lifespan.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.logger import logger as fastapi_logger
 
-from ..redis.redis import get_redis_session_context
+from ..redis.redis import get_redis_session_context, pool
 
 
 async def on_startup(app: FastAPI):
@@ -14,6 +14,8 @@ async def on_startup(app: FastAPI):
 
 
 async def on_shutdown(app: FastAPI):
+    fastapi_logger.info(f"Closing Redis connection...")
+    await pool.aclose()
     fastapi_logger.info(f"{app.title} server stopped.")
 
 


### PR DESCRIPTION
This pull request adds code to close the Redis connection pool on server shutdown. This ensures that the connection pool is properly closed and resources are released.