### PR TITLE
🦄 refactor: Refactor: Remove private key field in API gateway

### DIFF
--- a/src/chaserland_api_gateway/config/jwt.py
+++ b/src/chaserland_api_gateway/config/jwt.py
@@ -3,7 +3,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class JWTSettings(BaseSettings):
-    PRIVATE_KEY: SecretStr = SecretStr("")
     PUBLIC_KEY: SecretStr = SecretStr("")
     ALGORITHM: str = ""
     MODE: str = ""


### PR DESCRIPTION
This pull request removes the private key field in the API gateway as it is not needed. The JWTSettings class in the codebase no longer includes the PRIVATE_KEY field. This change improves the security and simplifies the codebase.