### PR TITLE
🦄 refactor: Remove ServerErrorMiddleware, change server header and update redis connection call

### DIFF
--- a/src/chaserland_api_gateway/middlewares/http.py
+++ b/src/chaserland_api_gateway/middlewares/http.py
@@ -2,10 +2,7 @@ import http
 import logging
 import time
 
-import grpc
-from chaserland_common.grpc.utils import to_http_status
 from fastapi import HTTPException, Request
-from fastapi.logger import logger as fastapi_logger
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
@@ -54,39 +51,6 @@ class RateLimiterMiddleware(BaseHTTPMiddleware):
         response.headers["X-RateLimit-Reset"] = str(rate_info.reset)
         response.headers["X-RateLimit-Used"] = str(rate_info.used)
         return response
-
-
-class ServerErrorMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app):
-        super().__init__(app)
-
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
-        try:
-            response = await call_next(request)
-            return response
-        except grpc.aio.AioRpcError as e:
-            status_code = to_http_status(e.code())
-            content = {
-                "detail": e.details() if status_code < 500 else "Internal server error"
-            }
-            return JSONResponse(
-                status_code=status_code,
-                content=content,
-            )
-        except Exception as e:
-            url = (
-                f"{request.url.path}?{request.query_params}"
-                if request.query_params
-                else request.url.path
-            )
-            fastapi_logger.error(
-                f'"{request.method} {url}" 500 "{type(e).__name__}: {e}"',
-                exc_info=True,
-            )
-            return JSONResponse(
-                status_code=500,
-                content={"detail": "Internal server error"},
-            )
 
 
 class LogRequestMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
This pull request refactors the server header in the dispatch middleware to use the FastAPI instance title instead of a fixed value. It also updates the redis connection call in the rate limiter middleware to use a context manager instead of a session loop.